### PR TITLE
Link zum Wiki

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,3 +1,9 @@
+----
+-layout: page
+-title: About
+-permalink: /about/
+----
+
 Informationen über dieses Projekt / What is this project about (Information in German): 
 
 https://github.com/python-forum-de/python-forum-de.github.io/wiki

--- a/about.md
+++ b/about.md
@@ -1,8 +1,10 @@
----
-layout: page
-title: About
-permalink: /about/
----
+Informationen über dieses Projekt / What is this project about (Information in German): 
+
+https://github.com/python-forum-de/python-forum-de.github.io/wiki
+
+-----
+
+Information about the software used for this webblog:
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)
 


### PR DESCRIPTION
Link zum Wiki eingefügt.

Dort gibt es genug "About" Infos. Macht keinen Sinn, sie an mehreren Stellen zu pflegen.

Die Infos über Jekyll sind erstmal drin geblieben, falls sie noch jemand benötigen sollte, allerdings entsprechend tituliert.

Leider ist die Seite dadurch zweisprachig, deutsch und englisch gemischt.,
